### PR TITLE
Proposal: SQS handlers

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -45,7 +45,7 @@ func APIGatewayProxyHandler(
 	conf HandlerConfig,
 ) func(context.Context, events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	return func(ctx context.Context, r events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-		correlationID := getCorrelationID(r)
+		correlationID := getCorrelationIDAPIGW(r)
 
 		logger := conf.Logger.With().
 			Str("application", conf.AppName).
@@ -176,7 +176,7 @@ func ErrValidation(detail string) Err {
 	}
 }
 
-func getCorrelationID(r events.APIGatewayProxyRequest) string {
+func getCorrelationIDAPIGW(r events.APIGatewayProxyRequest) string {
 	correlationID := r.Headers[headerCorrelationID]
 	if correlationID != "" {
 		return correlationID

--- a/sqs_handler.go
+++ b/sqs_handler.go
@@ -1,0 +1,135 @@
+package g8
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/google/uuid"
+	newrelic "github.com/newrelic/go-agent"
+	"github.com/newrelic/go-agent/_integrations/nrlambda"
+	"github.com/rs/zerolog"
+)
+
+type SQSContext struct {
+	Context       context.Context
+	Message       events.SQSMessage
+	Logger        zerolog.Logger
+	NewRelicTx    newrelic.Transaction
+	CorrelationID string
+}
+
+type SQSHandlerFunc func(c *SQSContext) error
+
+type SQSMessageEnvelope struct {
+	Data interface{}     `json:"data"`
+	Meta *SQSMessageMeta `json:"meta"`
+}
+
+type SQSMessageMeta struct {
+	CorrelationID string `json:"correlation_id"`
+}
+
+func SQSHandler(h SQSHandlerFunc, conf HandlerConfig) func(context.Context, events.SQSEvent) error {
+	return func(ctx context.Context, e events.SQSEvent) error {
+		for _, record := range e.Records {
+			// parse the envelope and get the meta data if available
+			// the body should then be updated with the inner message
+			// data for when the data is bound.
+			meta, dataBytes := parseRawMessage([]byte(record.Body))
+			record.Body = string(dataBytes)
+
+			correlationID := getCorrelationIDSQS(meta)
+
+			logger := conf.Logger.With().
+				Str("application", conf.AppName).
+				Str("function_name", conf.FunctionName).
+				Str("env", conf.EnvName).
+				Str("build_version", conf.BuildVersion).
+				Str("correlation_id", correlationID).
+				Str("sqs_event_source", record.EventSource).
+				Str("sqs_message_id", record.MessageId).
+				Logger()
+
+			c := &SQSContext{
+				Context:       ctx,
+				Message:       record,
+				Logger:        logger,
+				NewRelicTx:    newrelic.FromContext(ctx),
+				CorrelationID: correlationID,
+			}
+
+			c.AddNewRelicAttribute("functionName", conf.FunctionName)
+			c.AddNewRelicAttribute("sqsEventSource", record.EventSource)
+			c.AddNewRelicAttribute("sqsMessageID", record.MessageId)
+			c.AddNewRelicAttribute("correlationID", correlationID)
+			c.AddNewRelicAttribute("buildVersion", conf.BuildVersion)
+
+			err := h(c)
+			if err != nil {
+				c.Logger.Error().Msgf("Unhandled error: %+v", err)
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func SQSHandlerWithNewRelic(h SQSHandlerFunc, conf HandlerConfig) lambda.Handler {
+	return nrlambda.Wrap(SQSHandler(h, conf), conf.NewRelicApp)
+}
+
+func (c *SQSContext) AddNewRelicAttribute(key string, val interface{}) {
+	if c.NewRelicTx == nil {
+		return
+	}
+	if err := c.NewRelicTx.AddAttribute(key, val); err != nil {
+		c.Logger.Error().Msgf("failed to add attr '%s' to new relic tx: %+v", key, err)
+	}
+}
+
+func (c *SQSContext) Bind(v interface{}) error {
+	if err := json.Unmarshal([]byte(c.Message.Body), v); err != nil {
+		return err
+	}
+
+	if validatable, ok := v.(Validatable); ok {
+		err := validatable.Validate()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func parseRawMessage(body []byte) (*SQSMessageMeta, []byte) {
+	var envelope SQSMessageEnvelope
+	err := json.Unmarshal(body, &envelope)
+	if err != nil {
+		// errors are swallowed here because the message body isn't guaranteed to be
+		// in the envelope type - if not, we should return the entire body
+		return nil, body
+	}
+
+	if envelope.Meta == nil {
+		// if meta is nil, it means the data wasn't enveloped
+		return nil, body
+	}
+
+	// we want to return the raw JSON of the inner message so it can be bound by the application
+	b, err := json.Marshal(envelope.Data)
+	if err != nil {
+		return nil, body
+	}
+
+	return envelope.Meta, b
+}
+
+func getCorrelationIDSQS(m *SQSMessageMeta) string {
+	if m == nil || m.CorrelationID == "" {
+		return uuid.New().String()
+	}
+	return m.CorrelationID
+}

--- a/sqs_handler_test.go
+++ b/sqs_handler_test.go
@@ -1,0 +1,209 @@
+package g8
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSQSHandler_SingleMessage(t *testing.T) {
+	timesCalled := 0
+	handlerFunc := func(c *SQSContext) error {
+		timesCalled++
+		var data map[string]string
+		err := c.Bind(&data)
+		if err != nil {
+			return err
+		}
+
+		assert.Equal(t, "value1", data["key1"])
+		assert.Equal(t, "abcdef", c.CorrelationID)
+
+		return nil
+	}
+
+	h := SQSHandler(handlerFunc, HandlerConfig{
+		Logger: zerolog.New(ioutil.Discard),
+	})
+	err := h(context.Background(), events.SQSEvent{Records: []events.SQSMessage{
+		{
+			Body: `{
+                     "data": {
+                       "key1": "value1",
+                       "key2": "value2"
+                     },
+                     "meta": {
+                       "correlation_id": "abcdef"
+                     }
+                   }`,
+		},
+	}})
+
+	assert.Nil(t, err)
+	assert.Equal(t, 1, timesCalled)
+}
+
+func TestSQSHandler_MultipleMessages(t *testing.T) {
+	timesCalled := 0
+	handlerFunc := func(c *SQSContext) error {
+		timesCalled++
+		var data map[string]string
+		err := c.Bind(&data)
+		if err != nil {
+			return err
+		}
+
+		assert.Equal(t, fmt.Sprintf("message-%d", timesCalled), data["message"])
+		assert.Equal(t, "abcdef", c.CorrelationID)
+
+		return nil
+	}
+
+	h := SQSHandler(handlerFunc, HandlerConfig{
+		Logger: zerolog.New(ioutil.Discard),
+	})
+	err := h(context.Background(), events.SQSEvent{Records: []events.SQSMessage{
+		{
+			Body: `{
+                     "data": {
+                       "message": "message-1"
+                     },
+                     "meta": {
+                       "correlation_id": "abcdef"
+                     }
+                   }`,
+		},
+		{
+			Body: `{
+                     "data": {
+                       "message": "message-2"
+                     },
+                     "meta": {
+                       "correlation_id": "abcdef"
+                     }
+                   }`,
+		},
+	}})
+
+	assert.Nil(t, err)
+	assert.Equal(t, 2, timesCalled)
+}
+
+func TestSQSHandler_EnvelopeNoCorrelationID(t *testing.T) {
+	timesCalled := 0
+	handlerFunc := func(c *SQSContext) error {
+		timesCalled++
+		var data map[string]string
+		err := c.Bind(&data)
+		if err != nil {
+			return err
+		}
+
+		assert.Equal(t, "value1", data["key1"])
+		assert.Len(t, c.CorrelationID, 36)
+
+		return nil
+	}
+
+	h := SQSHandler(handlerFunc, HandlerConfig{
+		Logger: zerolog.New(ioutil.Discard),
+	})
+	err := h(context.Background(), events.SQSEvent{Records: []events.SQSMessage{
+		{
+			Body: `{
+                     "data": {
+                       "key1": "value1",
+                       "key2": "value2"
+                     },
+                     "meta": {}
+                   }`,
+		},
+	}})
+
+	assert.Nil(t, err)
+	assert.Equal(t, 1, timesCalled)
+}
+
+func TestSQSHandler_NoEnvelope(t *testing.T) {
+	timesCalled := 0
+	handlerFunc := func(c *SQSContext) error {
+		timesCalled++
+		var data map[string]string
+		err := c.Bind(&data)
+		if err != nil {
+			return err
+		}
+
+		assert.Equal(t, "value1", data["key1"])
+		assert.Len(t, c.CorrelationID, 36)
+
+		return nil
+	}
+
+	h := SQSHandler(handlerFunc, HandlerConfig{
+		Logger: zerolog.New(ioutil.Discard),
+	})
+	err := h(context.Background(), events.SQSEvent{Records: []events.SQSMessage{
+		{
+			Body: `{
+                     "key1": "value1",
+                     "key2": "value2"
+                   }`,
+		},
+	}})
+
+	assert.Nil(t, err)
+	assert.Equal(t, 1, timesCalled)
+}
+
+func TestSQSHandler_InvalidJSON(t *testing.T) {
+	timesCalled := 0
+	handlerFunc := func(c *SQSContext) error {
+		timesCalled++
+		var data map[string]string
+		err := c.Bind(&data)
+		assert.NotNil(t, err)
+		return err
+	}
+
+	h := SQSHandler(handlerFunc, HandlerConfig{
+		Logger: zerolog.New(ioutil.Discard),
+	})
+	err := h(context.Background(), events.SQSEvent{Records: []events.SQSMessage{
+		{
+			Body: `not valid json`,
+		},
+	}})
+
+	assert.NotNil(t, err)
+	assert.Equal(t, "invalid character 'o' in literal null (expecting 'u')", err.Error())
+	assert.Equal(t, 1, timesCalled)
+}
+
+func TestSQSHandler_HandlerError(t *testing.T) {
+	timesCalled := 0
+	handlerFunc := func(c *SQSContext) error {
+		timesCalled++
+		return assert.AnError
+	}
+
+	h := SQSHandler(handlerFunc, HandlerConfig{
+		Logger: zerolog.New(ioutil.Discard),
+	})
+	err := h(context.Background(), events.SQSEvent{Records: []events.SQSMessage{
+		{
+			Body: `{
+                     "key1": "value1",
+                     "key2": "value2"
+                   }`,
+		},
+	}})
+
+	assert.Equal(t, assert.AnError, err)
+	assert.Equal(t, 1, timesCalled)
+}


### PR DESCRIPTION
SQS handlers - shares the HandlerConfig, and very similar pattern to APIGW handlers. 

**NOTE:** this handles both enveloped and non-enveloped messages.
