### PR TITLE
Include stack trace when logging unhandled errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,11 @@ Writes the the following response, with status code 400
   "detail": "Invalid param"
 }
 ```
+
+### Logging stack traces
+
+Unhandled errors are logged automatically with a stack trace if the error is wrapped by [eris](https://github.com/rotisserie/eris). 
+
+```go
+eris.Wrapf(err, "failed to send offers to user id: %v", userID)
+```

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,12 @@ module github.com/JSainsburyPLC/g8
 go 1.13
 
 require (
+	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/aws/aws-lambda-go v1.13.3
 	github.com/gaw508/lambda-proxy-http-adapter v0.1.0
 	github.com/google/uuid v1.1.1
 	github.com/newrelic/go-agent v3.0.0+incompatible
+	github.com/rotisserie/eris v0.2.0
 	github.com/rs/zerolog v1.17.2
 	github.com/steinfletcher/apitest v1.4.0
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,9 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/PaesslerAG/gval v1.0.0 h1:GEKnRwkWDdf9dOmKcNrar9EA1bz1z9DqPIO1+iLzhd8=
+github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
+github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
+github.com/PaesslerAG/jsonpath v0.1.1 h1:c1/AToHQMVsduPAa4Vh6xp2U0evy4t8SWp8imEsylIk=
+github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
 github.com/aws/aws-lambda-go v1.13.3 h1:SuCy7H3NLyp+1Mrfp+m80jcbi9KYWAs9/BXwppwRDzY=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
@@ -14,6 +19,8 @@ github.com/newrelic/go-agent v3.0.0+incompatible/go.mod h1:a8Fv1b/fYhFSReoTU6HDk
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rotisserie/eris v0.2.0 h1:WRSj1amcCF98U04ur8Sj1oOKRRaFwvJ6i+z+97jfiXc=
+github.com/rotisserie/eris v0.2.0/go.mod h1:DfmQXutjjasYYOYqyqgnevbDzsVLOwG/KWlwVkBoU3U=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.17.2 h1:RMRHFw2+wF7LO0QqtELQwo8hqSmqISyCJeFeAAuWcRo=
 github.com/rs/zerolog v1.17.2/go.mod h1:9nvC1axdVrAHcu/s9taAVfBuIdTZLVQmKQyvrUjF5+I=


### PR DESCRIPTION
Use eris instead of pkg/errors to create the stack trace because it supports writing the stack trace to json.